### PR TITLE
Update Copyright to include 2015

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -38,7 +38,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'Buildout'
-copyright = '2006-2013, Zope Foundation'
+copyright = '2006-2015, Zope Foundation'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.


### PR DESCRIPTION
the copyright is an indicator of the health of the project and should be recent.